### PR TITLE
use plugin.stop to return from run

### DIFF
--- a/logstash-input-udp.gemspec
+++ b/logstash-input-udp.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core", "~> 2.0.0.snapshot"
 
   s.add_runtime_dependency 'logstash-codec-plain'
+  s.add_runtime_dependency 'stud', '~> 0.0.22'
   s.add_development_dependency 'logstash-devutils'
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ module UdpHelpers
     result = nevents.times.inject([]) do |acc|
       acc << queue.pop
     end
-    input_thread.raise(LogStash::ShutdownSignal)
+    plugin.stop
     result
   end
 


### PR DESCRIPTION
Implements `stop` to return from `run` according to https://github.com/elastic/logstash/issues/3210

Depends on https://github.com/elastic/logstash-devutils/pull/32 and https://github.com/elastic/logstash/pull/3812

resolves #8 