### PR TITLE
move socket creation/binding to register and remove internal restart

### DIFF
--- a/lib/logstash/inputs/udp.rb
+++ b/lib/logstash/inputs/udp.rb
@@ -39,24 +39,6 @@ class LogStash::Inputs::Udp < LogStash::Inputs::Base
 
   public
   def register
-    @udp = nil
-  end # def register
-
-  public
-  def run(output_queue)
-  @output_queue = output_queue
-    begin
-      # udp server
-      udp_listener(output_queue)
-    rescue => e
-      @logger.warn("UDP listener died", :exception => e, :backtrace => e.backtrace)
-      Stud.stoppable_sleep(5) { stop? }
-      retry unless stop?
-    end # begin
-  end # def run
-
-  private
-  def udp_listener(output_queue)
     @logger.info("Starting UDP listener", :address => "#{@host}:#{@port}")
 
     if @udp && ! @udp.closed?
@@ -67,7 +49,23 @@ class LogStash::Inputs::Udp < LogStash::Inputs::Base
     @udp.bind(@host, @port)
 
     @input_to_worker = SizedQueue.new(@queue_size)
+  end # def register
 
+  public
+  def run(output_queue)
+    @output_queue = output_queue
+    begin
+      # udp server
+      udp_listener
+    rescue => e
+      @logger.warn("UDP listener died", :exception => e, :backtrace => e.backtrace)
+      Stud.stoppable_sleep(5) { stop? }
+      retry unless stop?
+    end # begin
+  end # def run
+
+  private
+  def udp_listener
     @input_workers = @workers.times do |i|
       @logger.debug("Starting UDP worker thread", :worker => i)
       Thread.new { inputworker(i) }

--- a/spec/inputs/udp_spec.rb
+++ b/spec/inputs/udp_spec.rb
@@ -4,7 +4,7 @@ require_relative "../support/client"
 
 describe LogStash::Inputs::Udp do
 
-  before do
+  before :all do
     srand(RSpec.configuration.seed)
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,7 @@ module UdpHelpers
     result = nevents.times.inject([]) do |acc|
       acc << queue.pop
     end
-    plugin.stop
+    plugin.do_stop
     result
   end
 

--- a/spec/support/client.rb
+++ b/spec/support/client.rb
@@ -14,15 +14,6 @@ module LogStash::Inputs::Test
       socket.connect(host, port)
     end
 
-    def send(msg="")
-      begin
-        send(msg)
-      rescue Exception => e
-        puts "send.exception", e
-        retry
-      end
-    end
-
     def send(msg)
       socket.connect(host, port) if socket.closed?
       socket.send(msg, 0)


### PR DESCRIPTION
The current design has a few problems:

* the internal queue is erased and recreated if there's an exception
* register doesn't do anything useful so binding happens in run
* specs rely on udp socket being bound in register therefore may fail occasionally
* there's an internal restart strategy that overlaps with the inputworker's

This PR moves binding to register and removes the internal restart, fixing the problems above

fixes #9 