### PR TITLE
codec exception no longer causes inputworker to stop running

### DIFF
--- a/lib/logstash/inputs/udp.rb
+++ b/lib/logstash/inputs/udp.rb
@@ -100,7 +100,9 @@ class LogStash::Inputs::Udp < LogStash::Inputs::Base
         end
       end
     rescue => e
-      @logger.error("Exception in inputworker", "exception" => e, "backtrace" => e.backtrace)
+      @logger.warn("Exception in inputworker", "exception" => e, "backtrace" => e.backtrace)
+      sleep(5)
+      retry
     end
   end # def inputworker
 


### PR DESCRIPTION
The exception is now caught and handled just like when an TCP listener dies.
Refer to issue https://github.com/logstash-plugins/logstash-input-udp/issues/3 for more information.
