### PR TITLE
avoid clashing with devutils input function

### DIFF
--- a/spec/inputs/udp_spec.rb
+++ b/spec/inputs/udp_spec.rb
@@ -27,7 +27,7 @@ describe LogStash::Inputs::Udp do
     let(:nevents) { 10 }
 
     let(:events) do
-      input(subject, nevents) do
+      udp_input(subject, nevents) do
         nevents.times do |i|
           client.send("msg #{i}")
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,7 +10,7 @@ end
 
 module UdpHelpers
 
-  def input(plugin, size, &block)
+  def udp_input(plugin, size, &block)
     queue = Queue.new
     input_thread = Thread.new do
       plugin.run(queue)


### PR DESCRIPTION
devutils already defines an input helper function, by redefining it, it breaks running multiple plugin tests in a single spec run. this patch simply ensured there's no clash in helper name 