### PR TITLE
Make test pass within the context of the LS Core Defaults plugins test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.2
+ - Adapt the test style to be able to run within the context of the LS
+   core default plugins test (integration)
+
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895

--- a/logstash-input-udp.gemspec
+++ b/logstash-input-udp.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-udp'
-  s.version         = '2.0.1'
+  s.version         = '2.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Read messages as events over the network via udp."
   s.description     = "This gem is a logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/plugin install gemname. This gem is not a stand-alone program"

--- a/spec/inputs/udp_spec.rb
+++ b/spec/inputs/udp_spec.rb
@@ -8,8 +8,9 @@ describe LogStash::Inputs::Udp do
     srand(RSpec.configuration.seed)
   end
 
-  let(:port)       { rand(1024..65535) }
-  subject { LogStash::Plugin.lookup("input", "udp").new({ "port" => port }) }
+  let!(:helper) { UdpHelpers.new }
+  let(:port)   { rand(1024..65535) }
+  subject      { LogStash::Plugin.lookup("input", "udp").new({ "port" => port }) }
 
   after :each do
     subject.close rescue nil
@@ -27,7 +28,7 @@ describe LogStash::Inputs::Udp do
     let(:nevents) { 10 }
 
     let(:events) do
-      input(subject, nevents) do
+      helper.input(subject, nevents) do
         nevents.times do |i|
           client.send("msg #{i}")
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,7 @@ class LogStash::Inputs::Udp
   attr_reader :udp
 end
 
-module UdpHelpers
+class UdpHelpers
 
   def input(plugin, size, &block)
     queue = Queue.new
@@ -20,15 +20,11 @@ module UdpHelpers
     sleep 0.1 until (plugin.udp && !plugin.udp.closed?)
     block.call
     sleep 0.1 while queue.size != size
-    result = nevents.times.inject([]) do |acc|
+    result = size.times.inject([]) do |acc|
       acc << queue.pop
     end
     plugin.do_stop
     result
   end
 
-end
-
-RSpec.configure do |c|
-  c.include UdpHelpers
 end


### PR DESCRIPTION
For this plugin this means including the helpers in another way as using the standard rspec.configure is not working in the situation described in the title.

This is not standard rspec, although necessary because of:

* The way we run LS default plugins tests.
* The fact that this helper is not generic enough to be moved into devutils.