### PR TITLE
  Add receive_buffer_bytes config setting to optionally set socket receive buffer size in bytes

### DIFF
--- a/lib/logstash/inputs/udp.rb
+++ b/lib/logstash/inputs/udp.rb
@@ -24,6 +24,12 @@ class LogStash::Inputs::Udp < LogStash::Inputs::Base
   # The maximum packet size to read from the network
   config :buffer_size, :validate => :number, :default => 65536
 
+  # The socket receive buffer size in bytes.
+  # If option is not set, the operating system default is used.
+  # The operating system will use the max allowed value if receive_buffer_size is larger than allowed.
+  # Consult your operating system documentation if you need to increase this max allowed value.
+  config :receive_buffer_size, :validate => :number
+
   # Number of threads processing packets
   config :workers, :validate => :number, :default => 2
 
@@ -64,7 +70,17 @@ class LogStash::Inputs::Udp < LogStash::Inputs::Base
     end
 
     @udp = UDPSocket.new(Socket::AF_INET)
+    # set socket receive buffer size if configured
+    if @receive_buffer_size
+      @udp.setsockopt(Socket::SOL_SOCKET, Socket::SO_RCVBUF, @receive_buffer_size)
+    end
+    rcvbuf = @udp.getsockopt(Socket::SOL_SOCKET, Socket::SO_RCVBUF).unpack("i")[0]
+    if @receive_buffer_size and rcvbuf != @receive_buffer_size
+      @logger.warn("Unable to set receive_buffer_size to desired size. Requested #{@receive_buffer_size} but obtained #{rcvbuf} bytes.")
+    end
+
     @udp.bind(@host, @port)
+    @logger.info("UDP listener started", :address => "#{@host}:#{@port}", :receive_buffer_size => "#{rcvbuf}", :queue_size => "#{@queue_size}")
 
     @input_to_worker = SizedQueue.new(@queue_size)
 

--- a/lib/logstash/inputs/udp.rb
+++ b/lib/logstash/inputs/udp.rb
@@ -26,9 +26,9 @@ class LogStash::Inputs::Udp < LogStash::Inputs::Base
 
   # The socket receive buffer size in bytes.
   # If option is not set, the operating system default is used.
-  # The operating system will use the max allowed value if receive_buffer_size is larger than allowed.
+  # The operating system will use the max allowed value if receive_buffer_bytes is larger than allowed.
   # Consult your operating system documentation if you need to increase this max allowed value.
-  config :receive_buffer_size, :validate => :number
+  config :receive_buffer_bytes, :validate => :number
 
   # Number of threads processing packets
   config :workers, :validate => :number, :default => 2
@@ -71,16 +71,16 @@ class LogStash::Inputs::Udp < LogStash::Inputs::Base
 
     @udp = UDPSocket.new(Socket::AF_INET)
     # set socket receive buffer size if configured
-    if @receive_buffer_size
-      @udp.setsockopt(Socket::SOL_SOCKET, Socket::SO_RCVBUF, @receive_buffer_size)
+    if @receive_buffer_bytes
+      @udp.setsockopt(Socket::SOL_SOCKET, Socket::SO_RCVBUF, @receive_buffer_bytes)
     end
     rcvbuf = @udp.getsockopt(Socket::SOL_SOCKET, Socket::SO_RCVBUF).unpack("i")[0]
-    if @receive_buffer_size and rcvbuf != @receive_buffer_size
-      @logger.warn("Unable to set receive_buffer_size to desired size. Requested #{@receive_buffer_size} but obtained #{rcvbuf} bytes.")
+    if @receive_buffer_bytes and rcvbuf != @receive_buffer_bytes
+      @logger.warn("Unable to set receive_buffer_bytes to desired size. Requested #{@receive_buffer_bytes} but obtained #{rcvbuf} bytes.")
     end
 
     @udp.bind(@host, @port)
-    @logger.info("UDP listener started", :address => "#{@host}:#{@port}", :receive_buffer_size => "#{rcvbuf}", :queue_size => "#{@queue_size}")
+    @logger.info("UDP listener started", :address => "#{@host}:#{@port}", :receive_buffer_bytes => "#{rcvbuf}", :queue_size => "#{@queue_size}")
 
     @input_to_worker = SizedQueue.new(@queue_size)
 

--- a/lib/logstash/inputs/udp.rb
+++ b/lib/logstash/inputs/udp.rb
@@ -75,7 +75,7 @@ class LogStash::Inputs::Udp < LogStash::Inputs::Base
       @udp.setsockopt(Socket::SOL_SOCKET, Socket::SO_RCVBUF, @receive_buffer_bytes)
     end
     rcvbuf = @udp.getsockopt(Socket::SOL_SOCKET, Socket::SO_RCVBUF).unpack("i")[0]
-    if @receive_buffer_bytes and rcvbuf != @receive_buffer_bytes
+    if @receive_buffer_bytes && rcvbuf != @receive_buffer_bytes
       @logger.warn("Unable to set receive_buffer_bytes to desired size. Requested #{@receive_buffer_bytes} but obtained #{rcvbuf} bytes.")
     end
 


### PR DESCRIPTION
Fixes #22 

I used receive_buffer_bytes  as config option name as kafka plugin uses that name as well.

Also an interesting thing I noticed during testing is that when run under jruby, it appears that the receive buffer is actually set to only half the configured value of net.core.rmem_default. Behavior is the same under OpenJDK and Oracle Java

```
:~$ sysctl net.core.rmem_default
net.core.rmem_default = 212992

:~$ rvm use jruby
Using jruby-9.0.5.0
:~$ ruby -ve  'require "socket"; @udp = UDPSocket.new(Socket::AF_INET); puts @udp.getsockopt(Socket::SOL_SOCKET, Socket::SO_RCVBUF).unpack("i")[0]'
jruby 9.0.5.0 (2.2.3) 2016-01-26 7bee00d OpenJDK 64-Bit Server VM 25.91-b14 on 1.8.0_91-8u91-b14-0ubuntu4~14.04-b14 +jit [linux-amd64]
106496

$ rvm use jruby-1.7
Using jruby-1.7.23
~$ ruby -ve  'require "socket"; @udp = UDPSocket.new(Socket::AF_INET); puts @udp.getsockopt(Socket::SOL_SOCKET, Socket::SO_RCVBUF).unpack("i")[0]'
jruby 1.7.23 (1.9.3p551) 2015-11-24 f496dd5 on OpenJDK 64-Bit Server VM 1.8.0_91-8u91-b14-0ubuntu4~14.04-b14 +jit [linux-amd64]
106496

~$ rvm use ruby
Using ruby-2.3.0
~$ ruby -ve  'require "socket"; @udp = UDPSocket.new(Socket::AF_INET); puts @udp.getsockopt(Socket::SOL_SOCKET, Socket::SO_RCVBUF).unpack("i")[0]'
ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-linux]
212992

:~$ rvm use ruby-1.9
Using ruby-1.9.3-p551
~$ ruby -ve  'require "socket"; @udp = UDPSocket.new(Socket::AF_INET); puts @udp.getsockopt(Socket::SOL_SOCKET, Socket::SO_RCVBUF).unpack("i")[0]'
ruby 1.9.3p551 (2014-11-13 revision 48407) [x86_64-linux]
212992
```