### PR TITLE
Fix IPv6 support.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,6 @@ matrix:
   fast_finish: true
 install: true
 script: ci/build.sh
+before_script:
+  - echo 0 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6
 jdk: oraclejdk8

--- a/lib/logstash/inputs/udp.rb
+++ b/lib/logstash/inputs/udp.rb
@@ -82,7 +82,11 @@ class LogStash::Inputs::Udp < LogStash::Inputs::Base
       @udp.close
     end
 
-    @udp = UDPSocket.new(Socket::AF_INET)
+    if IPAddr.new(@host).ipv6?
+      @udp = UDPSocket.new(Socket::AF_INET6)
+    elsif IPAddr.new(@host).ipv4?
+      @udp = UDPSocket.new(Socket::AF_INET)
+    end
     # set socket receive buffer size if configured
     if @receive_buffer_bytes
       @udp.setsockopt(Socket::SOL_SOCKET, Socket::SO_RCVBUF, @receive_buffer_bytes)

--- a/spec/support/client.rb
+++ b/spec/support/client.rb
@@ -1,21 +1,25 @@
 # encoding: utf-8
 require "socket"
+require "ipaddr"
 
 module LogStash::Inputs::Test
 
   class UDPClient
     attr_reader :host, :port, :socket
 
-    def initialize(port)
+    def initialize(port, host = "0.0.0.0")
+      @host = host
       @port = port
-      @host = "0.0.0.0"
-      @socket = UDPSocket.new
-      socket.connect(host, port)
+      if IPAddr.new(@host).ipv6?
+        @socket = UDPSocket.new(Socket::AF_INET6)
+      elsif IPAddr.new(@host).ipv4?
+        @socket = UDPSocket.new(Socket::AF_INET)
+      end
+      @socket.connect(host, port)
     end
 
     def send(msg)
       begin
-        socket.connect(host, port) if socket.closed?
         socket.send(msg, 0)
       rescue  => e
         puts("send exception, retrying", e.inspect)


### PR DESCRIPTION
In Logstash 5.x and below, JRuby 1.7.x is used, and
UDPSocket.new(Socket::AF_INET) somehow accidentally works with IPv6.

Logstash 6.x uses JRuby 9.x where this now behaves correctly (AF_INET is
ipv4 only), but triggers a bug where ipv6 was accidentally disabled in
the udp input. Oops!

This change is small (AF_INET -> AF_INET6) and adds tests to cover the
default scenario that 127.0.0.1 and ::1 both work for the default.