### PR TITLE
clone codec per worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.0
+  - Clone codec per worker. See https://github.com/logstash-plugins/logstash-input-udp/pull/32
+
 ## 3.1.3
   - Update gemspec summary
 

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -11,6 +11,7 @@ Contributors:
 * Pier-Hugues Pellerin (ph)
 * Richard Pijnenburg (electrical)
 * kcrayon
+* Colin Surprenant (colinsurprenant)
 
 Note: If you've sent us patches, bug reports, or otherwise contributed to
 Logstash, and you aren't on the list above and want to be, please let us know

--- a/logstash-input-udp.gemspec
+++ b/logstash-input-udp.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-udp'
-  s.version         = '3.1.3'
+  s.version         = '3.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events over UDP"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-input-udp.gemspec
+++ b/logstash-input-udp.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'stud', '~> 0.0.22'
+  s.add_development_dependency 'logstash-codec-line'
   s.add_development_dependency 'logstash-devutils'
 end
 

--- a/spec/support/client.rb
+++ b/spec/support/client.rb
@@ -4,7 +4,6 @@ require "socket"
 module LogStash::Inputs::Test
 
   class UDPClient
-
     attr_reader :host, :port, :socket
 
     def initialize(port)
@@ -14,24 +13,18 @@ module LogStash::Inputs::Test
       socket.connect(host, port)
     end
 
-    def send(msg="")
+    def send(msg)
       begin
-        send(msg)
-      rescue Exception => e
-        puts "send.exception", e
+        socket.connect(host, port) if socket.closed?
+        socket.send(msg, 0)
+      rescue  => e
+        puts("send exception, retrying", e.inspect)
         retry
       end
     end
 
-    def send(msg)
-      socket.connect(host, port) if socket.closed?
-      socket.send(msg, 0)
-    end
-
     def close
-      socket.close
+      socket.close unless socket.closed?
     end
-
   end
-
 end


### PR DESCRIPTION
Per discussion in elastic/logstash/issues/8830 each input worker should have its own codec instance.