### PR TITLE
update changelog for 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.3.0
-  - Add metrics support for events, operations, connections and errors produced during execution.
+  - Add metrics support for events, operations, connections and errors produced during execution. #34
+  - Fix support for IPv6 #31
 
 ## 3.2.1
   - Code cleanup. See https://github.com/logstash-plugins/logstash-input-udp/pull/33


### PR DESCRIPTION
changelog for 3.3.0:

```
% git lg v3.2.1..
* e6c6601 - (origin/master, origin/HEAD) add metrics support for events, operations, connections and errors produced during execution (13 hours ago) <Pere Urbon-Bayes>
* 79dd734 - fix travis ipv6 (13 hours ago) <Joao Duarte>
* 4aaef31 - Fix IPv6 support. (13 hours ago) <Jordan Sissel>
* 1532175 - [skip ci] update license to 2018 (2 months ago) <Joao Duarte>
```