### PR TITLE
fix missing ipaddr require

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.2
+  - Fix missing require for the ipaddr library.
+
 ## 3.3.1
   - Docs: Set the default_codec doc attribute.
 

--- a/lib/logstash/inputs/udp.rb
+++ b/lib/logstash/inputs/udp.rb
@@ -4,6 +4,7 @@ require "logstash/inputs/base"
 require "logstash/namespace"
 require "socket"
 require "stud/interval"
+require "ipaddr"
 
 # Read messages as events over the network via udp. The only required
 # configuration item is `port`, which specifies the udp port logstash

--- a/logstash-input-udp.gemspec
+++ b/logstash-input-udp.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-udp'
-  s.version         = '3.3.1'
+  s.version         = '3.3.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events over UDP"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
The `IPAddr` class is used but the `ipaddr` library is never required. If no other plugins does a `require "ipaddr"` then the udp input will crash on startup with:

```
[WARN ][logstash.inputs.udp ] UDP listener died {:exception=>#<NameError: uninitialized constant LogStash::Inputs::Udp::IPAddr>, :backtrace=>["org/jruby/RubyModule.java:2746:in const_missing'", "/usr/share/logstash/vendor/bundle/jruby/1.9/gems/logstash-input-udp-3.3.1/lib/logstash/inputs/udp.rb:87:inudp_listener'", "/usr/share/logstash/vendor/bundle/jruby/1.9/gems/logstash-input-udp-3.3.1/lib/logstash/inputs/udp.rb:57:in run'", "/usr/share/logstash/logstash-core/lib/logstash/pipeline.rb:470:ininputworker'", "/usr/share/logstash/logstash-core/lib/logstash/pipeline.rb:463:in `start_input'"]}
```

This fix is simply to require that library.