### PR TITLE
Work around memory issue with jruby/jruby#5148

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.3
+  - Work around jruby/jruby#5148 by cloning messages on jruby 9k, therefore resizing the underlying byte buffer
+
 ## 3.3.2
   - Fix missing require for the ipaddr library.
 

--- a/lib/logstash/inputs/udp.rb
+++ b/lib/logstash/inputs/udp.rb
@@ -154,7 +154,8 @@ class LogStash::Inputs::Udp < LogStash::Inputs::Base
   # message will use 64kb
   if RUBY_VERSION.match(/^2/)
     def push_data(payload, client)
-      @input_to_worker.push([payload.b, client])
+      payload = payload.b.force_encoding(Encoding::UTF_8)
+      @input_to_worker.push([payload, client])
     end
   else
     def push_data(payload, client)

--- a/logstash-input-udp.gemspec
+++ b/logstash-input-udp.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-udp'
-  s.version         = '3.3.2'
+  s.version         = '3.3.3'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events over UDP"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
on JRuby 9k, a read from the UDP socket will not truncate unused buffer space so we have to force it using String#s

Memory profile without this patch:

![screen shot 2018-05-02 at 15 46 18](https://user-images.githubusercontent.com/31809/39531556-5025f6ce-4e23-11e8-92b2-9a7e0887bb73.png)

With the patch:

![screen shot 2018-05-02 at 15 46 06](https://user-images.githubusercontent.com/31809/39531541-49f2f5ea-4e23-11e8-8be7-b058da155b2b.png)

fixes https://github.com/elastic/logstash/issues/9346