### PR TITLE
Make source IP field configurable

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -40,6 +40,7 @@ This plugin supports the following configuration options plus the <<plugins-{typ
 | <<plugins-{type}s-{plugin}-queue_size>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-receive_buffer_bytes>> |<<number,number>>|No
 | <<plugins-{type}s-{plugin}-workers>> |<<number,number>>|No
+| <<plugins-{type}s-{plugin}-source_ip_fieldname>> |<<string,string>>|No
 |=======================================================================
 
 Also see <<plugins-{type}s-{plugin}-common-options>> for a list of options supported by all
@@ -101,7 +102,13 @@ Consult your operating system documentation if you need to increase this max all
 
 Number of threads processing packets
 
+[id="plugins-{type}s-{plugin}-source_ip_fieldname"]
+===== `source_ip_fieldname`
 
+  * Value type is <<string,string>>
+  * Default value is `"host"`
+
+The name of the field where the source IP address will be stored.
 
 [id="plugins-{type}s-{plugin}-common-options"]
 include::{include_path}/{type}.asciidoc[]


### PR DESCRIPTION
Retains backwards compatibility and allows users to choose e.g.
`[@metadata][source_ip]` or an ECS-compatible field like `source.ip`.

Closes #40 
Closes #42 