### PR TITLE
input workers should not die upon codec exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.3.4
+  - Fixed input workers exception handling and shutdown handling [#44](https://github.com/logstash-plugins/logstash-input-udp/pull/44)
+
 ## 3.3.3
   - Work around jruby/jruby#5148 by cloning messages on jruby 9k, therefore resizing the underlying byte buffer
 

--- a/logstash-input-udp.gemspec
+++ b/logstash-input-udp.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-input-udp'
-  s.version         = '3.3.3'
+  s.version         = '3.3.4'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Reads events over UDP"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
This fixes 2 issues:
- upon a codec exception, the input worker executing that codec would die and when all workers died the udp input would be completely stalled upon filling it's internal queue without any workers to process the queued data at which point a logstash restart would be required resulting in the loss of all queued data waiting to be processed by the workers.

- the input workers where not aware of a shutdown condition and upon logstash shutdown, if data was queued, it could result in not finishing processing the queued data before exiting the plugin upon a shutdown. 