### PR TITLE
Add option to report UDP source IP address and port to codec

### DIFF
--- a/lib/logstash/inputs/udp.rb
+++ b/lib/logstash/inputs/udp.rb
@@ -151,9 +151,7 @@ class LogStash::Inputs::Udp < LogStash::Inputs::Base
 
         ip_address = client[3]
         if @metadata
-          metadata_to_codec = {}
-          metadata_to_codec["port"] = client[1]
-          metadata_to_codec["host"] = client[3]
+          metadata_to_codec = { "port" => client[1], "host" => client[3] }
         end
         codec.decode(payload, metadata_to_codec) { |event| push_decoded_event(ip_address, event) }
         codec.flush { |event| push_decoded_event(ip_address, event) }

--- a/lib/logstash/inputs/udp.rb
+++ b/lib/logstash/inputs/udp.rb
@@ -150,10 +150,8 @@ class LogStash::Inputs::Udp < LogStash::Inputs::Base
         break if payload == :END
 
         ip_address = client[3]
-        if @metadata
-          metadata_to_codec = { "port" => client[1], "host" => client[3] }
-        end
-        codec.decode(payload, metadata_to_codec) { |event| push_decoded_event(ip_address, event) }
+        optional_metadata = @metadata ? [{"port" => client[1], "host" => client[3]}] : []
+        codec.decode(payload, *optional_metadata) { |event| push_decoded_event(ip_address, event) }
         codec.flush { |event| push_decoded_event(ip_address, event) }
       rescue => e
         @logger.error("Exception in inputworker", "exception" => e, "backtrace" => e.backtrace)


### PR DESCRIPTION
This PR adds an option to report UDP source IP address and port to codec, which is disabled by default.

Related

- [logstash-plugins/logstash-codec-netflow/issues/76](https://github.com/logstash-plugins/logstash-codec-netflow/issues/76)
- [logstash-plugins/logstash-codec-netflow/issues/9](https://github.com/logstash-plugins/logstash-codec-netflow/issues/9)