### PR TITLE
Use Docker 2.4 instead of 3 in testing to run IPv6 specs

### DIFF
--- a/.ci/docker-compose.override.yml
+++ b/.ci/docker-compose.override.yml
@@ -1,0 +1,24 @@
+version: '2.4'
+
+services:
+  logstash:
+    container_name: udp_ls
+    command: /usr/share/plugins/plugin/.ci/run.sh
+    environment:
+      - ELASTIC_STACK_VERSION=$ELASTIC_STACK_VERSION
+    networks:
+      app_net:
+        ipv4_address: 172.16.238.10
+        ipv6_address: 2001:3984:3989::10
+
+networks:
+  app_net:
+    driver: bridge
+    enable_ipv6: true
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.16.238.0/24
+          gateway: 172.16.238.1
+        - subnet: 2001:3984:3989::/64
+          gateway: 2001:3984:3989::1

--- a/.ci/docker-compose.yml
+++ b/.ci/docker-compose.yml
@@ -1,0 +1,21 @@
+# docker ipv6 only support in version 2.x
+version: '2.4'
+
+# run tests:  cd ci/unit; docker-compose up --build --force-recreate
+# manual:  cd ci/unit; docker-compose run logstash bash
+services:
+
+  logstash:
+    build:
+      context: ../
+      dockerfile: .ci/Dockerfile
+      args:
+        - ELASTIC_STACK_VERSION=$ELASTIC_STACK_VERSION
+        - DISTRIBUTION=${DISTRIBUTION:-default}
+        #- INTEGRATION=false
+    command: .ci/run.sh
+    env_file: docker.env
+    environment:
+      - SPEC_OPTS
+      #- JRUBY_OPTS
+    tty: true


### PR DESCRIPTION
This PR customizes docker-compose files to use Docker 2.4 which let enable IPv6